### PR TITLE
Feature/sayan/fixed drop collection method

### DIFF
--- a/utils.js
+++ b/utils.js
@@ -350,8 +350,16 @@ var dropCollection = function dropCollection(name) {
   return MongoClient.connect(process.env.DB_URL, {promiseLibrary: Promise})
     .then(function dropDb(db) {
       dbHandleForShutDowns = db;
-      return db.collection(name).drop()
-        .finally(db.close.bind(db));
+      return db.listCollections().toArray();
+    })
+    .then(function (collections) {
+      if(collections.indexOf(name) > -1){
+        return db.collection(name).drop()
+          .finally(db.close.bind(db));
+      }
+      else {
+        return Promise.resolve(false);
+      }
     })
     .catch(function catchErrors(err) {
       if (dbHandleForShutDowns) {

--- a/utils.js
+++ b/utils.js
@@ -358,7 +358,7 @@ var dropCollection = function dropCollection(name) {
       });
       if(collectionNames.indexOf(name) > -1){
         return dbHandleForShutDowns.collection(name).drop()
-          .finally(dbHandleForShutDowns.close.bind(db));
+          .finally(dbHandleForShutDowns.close.bind(dbHandleForShutDowns));
       }
       else {
         return Promise.resolve(false);

--- a/utils.js
+++ b/utils.js
@@ -353,9 +353,12 @@ var dropCollection = function dropCollection(name) {
       return db.listCollections().toArray();
     })
     .then(function (collections) {
-      if(collections.indexOf(name) > -1){
-        return db.collection(name).drop()
-          .finally(db.close.bind(db));
+      var collectionNames = collections.map(function (collection) {
+        return collection.name;
+      });
+      if(collectionNames.indexOf(name) > -1){
+        return dbHandleForShutDowns.collection(name).drop()
+          .finally(dbHandleForShutDowns.close.bind(db));
       }
       else {
         return Promise.resolve(false);


### PR DESCRIPTION
Fixed the issue of dropping a collection in MongoDB. Will check for the existence of the collection in the database and then only proceed with dropping the db.

This extra check prevents the a lot of namespace errors generated by mongo.